### PR TITLE
Isolate curses dependency

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 game.log
 .pytest_cache/
 __pycache__/
+.coverage
+htmlcov/

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,10 @@ name = "pypi"
 black = "*"
 pytest = "*"
 ipython = "*"
+pytest-cov = "*"
 
 [requires]
 python_version = "3.7"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd9fd198fb464c21f0ec14dae753d11bd8071771f92b67c30db4ec5ea8ef5635"
+            "sha256": "870e3f8a1100bdfcaddf3892e60fcb51bcb5fc7bfc8b69910f4ba564c7e5547a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,17 +34,17 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
             ],
-            "version": "==1.1.5"
+            "version": "==1.3.0"
         },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.1.0"
+            "version": "==19.1.0"
         },
         "backcall": {
             "hashes": [
@@ -55,33 +55,67 @@
         },
         "black": {
             "hashes": [
-                "sha256:22158b89c1a6b4eb333a1e65e791a3f8b998cf3b11ae094adb2570f31f769a44",
-                "sha256:4b475bbd528acce094c503a3d2dbc2d05a4075f6d0ef7d9e7514518e14cc5191"
+                "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
+                "sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
             ],
             "index": "pypi",
-            "version": "==18.6b4"
+            "version": "==19.3b0"
         },
         "click": {
             "hashes": [
-                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
-                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "version": "==6.7"
+            "version": "==7.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:029c69deaeeeae1b15bc6c59f0ffa28aa8473721c614a23f2c2976dec245cd12",
+                "sha256:02abbbebc6e9d5abe13cd28b5e963dedb6ffb51c146c916d17b18f141acd9947",
+                "sha256:1bbfe5b82a3921d285e999c6d256c1e16b31c554c29da62d326f86c173d30337",
+                "sha256:210c02f923df33a8d0e461c86fdcbbb17228ff4f6d92609fc06370a98d283c2d",
+                "sha256:2d0807ba935f540d20b49d5bf1c0237b90ce81e133402feda906e540003f2f7a",
+                "sha256:35d7a013874a7c927ce997350d314144ffc5465faf787bb4e46e6c4f381ef562",
+                "sha256:3636f9d0dcb01aed4180ef2e57a4e34bb4cac3ecd203c2a23db8526d86ab2fb4",
+                "sha256:42f4be770af2455a75e4640f033a82c62f3fb0d7a074123266e143269d7010ef",
+                "sha256:48440b25ba6cda72d4c638f3a9efa827b5b87b489c96ab5f4ff597d976413156",
+                "sha256:4dac8dfd1acf6a3ac657475dfdc66c621f291b1b7422a939cc33c13ac5356473",
+                "sha256:4e8474771c69c2991d5eab65764289a7dd450bbea050bc0ebb42b678d8222b42",
+                "sha256:551f10ddfeff56a1325e5a34eff304c5892aa981fd810babb98bfee77ee2fb17",
+                "sha256:5b104982f1809c1577912519eb249f17d9d7e66304ad026666cb60a5ef73309c",
+                "sha256:5c62aef73dfc87bfcca32cee149a1a7a602bc74bac72223236b0023543511c88",
+                "sha256:633151f8d1ad9467b9f7e90854a7f46ed8f2919e8bc7d98d737833e8938fc081",
+                "sha256:772207b9e2d5bf3f9d283b88915723e4e92d9a62c83f44ec92b9bd0cd685541b",
+                "sha256:7d5e02f647cd727afc2659ec14d4d1cc0508c47e6cfb07aea33d7aa9ca94d288",
+                "sha256:a9798a4111abb0f94584000ba2a2c74841f2cfe5f9254709756367aabbae0541",
+                "sha256:b38ea741ab9e35bfa7015c93c93bbd6a1623428f97a67083fc8ebd366238b91f",
+                "sha256:b6a5478c904236543c0347db8a05fac6fc0bd574c870e7970faa88e1d9890044",
+                "sha256:c6248bfc1de36a3844685a2e10ba17c18119ba6252547f921062a323fb31bff1",
+                "sha256:c705ab445936457359b1424ef25ccc0098b0491b26064677c39f1d14a539f056",
+                "sha256:d95a363d663ceee647291131dbd213af258df24f41350246842481ec3709bd33",
+                "sha256:e27265eb80cdc5dab55a40ef6f890e04ecc618649ad3da5265f128b141f93f78",
+                "sha256:ebc276c9cb5d917bd2ae959f84ffc279acafa9c9b50b0fa436ebb70bbe2166ea",
+                "sha256:f4d229866d030863d0fe3bf297d6d11e6133ca15bbb41ed2534a8b9a3d6bd061",
+                "sha256:f95675bd88b51474d4fe5165f3266f419ce754ffadfb97f10323931fa9ac95e5",
+                "sha256:f95bc54fb6d61b9f9ff09c4ae8ff6a3f5edc937cda3ca36fc937302a7c152bf1",
+                "sha256:fd0f6be53de40683584e5331c341e65a679dbe5ec489a0697cec7c2ef1a48cda"
+            ],
+            "version": "==5.0a4"
         },
         "decorator": {
             "hashes": [
-                "sha256:2c51dff8ef3c447388fe5e4453d24a2bf128d3a4c32af3fabef1f01c6851ab82",
-                "sha256:c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c"
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
             ],
-            "version": "==4.3.0"
+            "version": "==4.4.0"
         },
         "ipython": {
             "hashes": [
-                "sha256:007dcd929c14631f83daff35df0147ea51d1af420da303fd078343878bd5fb62",
-                "sha256:b0f2ef9eada4a68ef63ee10b6dde4f35c840035c50fd24265f8052c98947d5a4"
+                "sha256:b038baa489c38f6d853a3cfc4c635b0cda66f2864d136fe8f40c1a6e334e2a6b",
+                "sha256:f5102c1cd67e399ec8ea66bcebe6e3968ea25a8977e53f012963e5affeb1fe38"
             ],
             "index": "pypi",
-            "version": "==6.5.0"
+            "version": "==7.4.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -92,56 +126,55 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1",
-                "sha256:c254b135fb39ad76e78d4d8f92765ebc9bf92cbc76f49e97ade1d5f5121e1f6f"
+                "sha256:2bb0603e3506f708e792c7f4ad8fc2a7a9d9c2d292a358fbbd58da531695595b",
+                "sha256:2c6bcd9545c7d6440951b12b44d373479bf18123a401a52025cf98563fbd826c"
             ],
-            "version": "==0.12.1"
+            "version": "==0.13.3"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
             ],
-            "version": "==4.3.0"
+            "markers": "python_version > '2.7'",
+            "version": "==7.0.0"
         },
         "parso": {
             "hashes": [
-                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
-                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
+                "sha256:17cc2d7a945eb42c3569d4564cdf49bde221bc2b552af3eca9c1aad517dcdd33",
+                "sha256:2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376"
             ],
-            "version": "==0.3.1"
+            "version": "==0.4.0"
         },
         "pexpect": {
             "hashes": [
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
+                "sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1",
+                "sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"
             ],
             "markers": "sys_platform != 'win32'",
-            "version": "==4.6.0"
+            "version": "==4.7.0"
         },
         "pickleshare": {
             "hashes": [
-                "sha256:84a9257227dfdd6fe1b4be1319096c20eb85ff1e82c7932f36efccfe1b09737b",
-                "sha256:c9a2541f25aeabc070f12f452e1f2a8eae2abd51e1cd19e8430402bdf4c1d8b5"
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
             ],
-            "version": "==0.7.4"
+            "version": "==0.7.5"
         },
         "pluggy": {
             "hashes": [
-                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
-                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version >= '2.7'",
-            "version": "==0.7.1"
+            "version": "==0.9.0"
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:1df952620eccb399c53ebb359cc7d9a8d3a9538cb34c5a1344bdbeb29fbcc381",
-                "sha256:3f473ae040ddaa52b52f97f6b4a493cfa9f5920c255a12dc56a7d34397a398a4",
-                "sha256:858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917"
+                "sha256:11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780",
+                "sha256:2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1",
+                "sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55"
             ],
-            "version": "==1.0.15"
+            "version": "==2.0.9"
         },
         "ptyprocess": {
             "hashes": [
@@ -152,45 +185,47 @@
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version >= '2.7'",
-            "version": "==1.5.4"
+            "version": "==1.8.0"
         },
         "pygments": {
             "hashes": [
-                "sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d",
-                "sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
+                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
+                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
             ],
-            "version": "==2.2.0"
+            "version": "==2.3.1"
         },
         "pytest": {
             "hashes": [
-                "sha256:3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02",
-                "sha256:96bfd45dbe863b447a3054145cd78a9d7f31475d2bce6111b133c0cc4f305118"
+                "sha256:13c5e9fb5ec5179995e9357111ab089af350d788cbc944c628f3cde72285809b",
+                "sha256:f21d2f1fb8200830dcbb5d8ec466a9c9120e20d8b53c7585d180125cce1d297a"
             ],
             "index": "pypi",
-            "version": "==3.7.2"
+            "version": "==4.4.0"
         },
-        "simplegeneric": {
+        "pytest-cov": {
             "hashes": [
-                "sha256:dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173"
+                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
+                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
             ],
-            "version": "==0.8.1"
+            "index": "pypi",
+            "version": "==2.6.1"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "toml": {
             "hashes": [
-                "sha256:8e86bd6ce8cc11b9620cb637466453d94f5d57ad86f17e98a98d1f73e3baab2d"
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
-            "version": "==0.9.4"
+            "version": "==0.10.0"
         },
         "traitlets": {
             "hashes": [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=. --cov-report html

--- a/tictactoe/app.py
+++ b/tictactoe/app.py
@@ -35,7 +35,7 @@ class Game:
         screens.configure_curses()
 
         # Welcome the player and ask for game type
-        welcome_screen = screens.WelcomeScreen(stdscr)
+        welcome_screen = screens.WelcomeScreen(screens.CursesWindow(stdscr))
         welcome_screen.draw()
         try:
             game_type = welcome_screen.get_game_type()
@@ -53,13 +53,13 @@ class Game:
         player1.token = "X"
         player2.token = "O"
 
-        token_screen = screens.TokenScreen(stdscr, player1, player2)
+        token_screen = screens.TokenScreen(screens.CursesWindow(stdscr), player1, player2)
         token_screen.draw()
         token_screen.update_player_tokens()
 
         if game_has_computer_players(game_type):
             # Set computer player difficulties
-            difficulty_screen = screens.DifficultyScreen(stdscr, player1, player2)
+            difficulty_screen = screens.DifficultyScreen(screens.CursesWindow(stdscr), player1, player2)
             difficulty_screen.draw()
             try:
                 difficulty_screen.update_computer_difficulties()
@@ -67,7 +67,7 @@ class Game:
                 return self.quit()
 
         # Set player order
-        order_screen = screens.OrderScreen(stdscr, player1, player2)
+        order_screen = screens.OrderScreen(screens.CursesWindow(stdscr), player1, player2)
         order_screen.draw()
         try:
             player1, player2 = order_screen.reorder_players()
@@ -77,7 +77,7 @@ class Game:
 
         # Play the game until it's over or a player quits
         board = Board(tokens=[player1.token, player2.token])
-        play_screen = screens.PlayScreen(stdscr, board, player1, player2)
+        play_screen = screens.PlayScreen(screens.CursesWindow(stdscr), board, player1, player2)
         try:
             play_screen.play()
         except exceptions.PlayerQuitException:
@@ -85,7 +85,7 @@ class Game:
 
         # Ask the player if they want to play again
         end_screen = screens.EndScreen(
-            stdscr, board, board_window=play_screen.board_window
+            screens.CursesWindow(stdscr), board, board_window=play_screen.board_window
         )
         play_again = end_screen.ask_play_again()
         if play_again:

--- a/tictactoe/app.py
+++ b/tictactoe/app.py
@@ -53,13 +53,17 @@ class Game:
         player1.token = "X"
         player2.token = "O"
 
-        token_screen = screens.TokenScreen(screens.CursesWindow(stdscr), player1, player2)
+        token_screen = screens.TokenScreen(
+            screens.CursesWindow(stdscr), player1, player2
+        )
         token_screen.draw()
         token_screen.update_player_tokens()
 
         if game_has_computer_players(game_type):
             # Set computer player difficulties
-            difficulty_screen = screens.DifficultyScreen(screens.CursesWindow(stdscr), player1, player2)
+            difficulty_screen = screens.DifficultyScreen(
+                screens.CursesWindow(stdscr), player1, player2
+            )
             difficulty_screen.draw()
             try:
                 difficulty_screen.update_computer_difficulties()
@@ -67,7 +71,9 @@ class Game:
                 return self.quit()
 
         # Set player order
-        order_screen = screens.OrderScreen(screens.CursesWindow(stdscr), player1, player2)
+        order_screen = screens.OrderScreen(
+            screens.CursesWindow(stdscr), player1, player2
+        )
         order_screen.draw()
         try:
             player1, player2 = order_screen.reorder_players()
@@ -77,7 +83,9 @@ class Game:
 
         # Play the game until it's over or a player quits
         board = Board(tokens=[player1.token, player2.token])
-        play_screen = screens.PlayScreen(screens.CursesWindow(stdscr), board, player1, player2)
+        play_screen = screens.PlayScreen(
+            screens.CursesWindow(stdscr), board, player1, player2
+        )
         try:
             play_screen.play()
         except exceptions.PlayerQuitException:

--- a/tictactoe/screens.py
+++ b/tictactoe/screens.py
@@ -11,6 +11,7 @@ logger = logging.getLogger("game")
 
 class CursesWindow:
     """A wrapper around a curses window application."""
+
     def __init__(self, stdscr):
         self.stdscr = stdscr
 

--- a/tictactoe/screens.py
+++ b/tictactoe/screens.py
@@ -9,21 +9,54 @@ from tictactoe import board, players, exceptions
 logger = logging.getLogger("game")
 
 
+class CursesWindow:
+    """A wrapper around a curses window application."""
+    def __init__(self, stdscr):
+        self.stdscr = stdscr
+
+    def addstr(self, *args, **kwargs):
+        self.stdscr.addstr(*args, **kwargs)
+
+    def getyx(self):
+        return self.stdscr.getyx()
+
+    def chgat(self, *args, **kwargs):
+        self.stdscr.chgat(*args, **kwargs)
+
+    def refresh(self):
+        self.stdscr.refresh()
+
+    def getkey(self):
+        return self.stdscr.getkey()
+
+    def move(self, y, x):
+        self.stdscr.move(y, x)
+
+    def clearln(self):
+        self.stdscr.deleteln()
+        self.stdscr.insertln()
+
+    def clear(self):
+        self.stdscr.clear()
+
+    def subwin(self, nlines, ncols, start_y, start_x):
+        return self.stdscr.subwin(nlines, ncols, start_y, start_x)
+
+
 class Screen:
     """Parent class for all TicTacToe screens."""
 
     prompt_y, error_y = 1, 2  # subclasses should overwrite these
     choice_delay = 0.5
 
-    def __init__(self, stdscr):
-        """Initialize the screen as a wrapper around a curses window."""
-        self.s = stdscr
+    def __init__(self, window):
+        self.window = window
 
     def draw_title(self, title):
-        self.s.addstr(0, 0, title)
+        self.window.addstr(0, 0, title)
 
     def draw_description(self, description):
-        self.s.addstr(1, 0, description)
+        self.window.addstr(1, 0, description)
 
     def get_key(
         self,
@@ -53,12 +86,12 @@ class Screen:
         """
         if prompt:
             self.draw_prompt(prompt)
-        yx = yx or self.s.getyx()
+        yx = yx or self.window.getyx()
         if default is not None:
-            self.s.addstr(yx[0], yx[1], default)
+            self.window.addstr(yx[0], yx[1], default)
 
             if show_help_text:
-                self.s.addstr(
+                self.window.addstr(
                     self.prompt_y + 1,
                     0,
                     "Press ENTER to accept the highlighted choice.",
@@ -67,17 +100,17 @@ class Screen:
 
         if highlight:
             if highlight_color_ix:
-                self.s.chgat(
+                self.window.chgat(
                     yx[0],
                     yx[1],
                     1,
                     curses.color_pair(highlight_color_ix) | curses.A_STANDOUT,
                 )
             else:
-                self.s.chgat(yx[0], yx[1], 1, curses.A_STANDOUT)
-        self.s.refresh()
+                self.window.chgat(yx[0], yx[1], 1, curses.A_STANDOUT)
+        self.window.refresh()
         while True:
-            key = self.s.getkey()
+            key = self.window.getkey()
             # The enter key is "\n" when using getkey() or the constant curses.KEY_ENTER when using getch()
             if key == "\n" and default is not None:
                 key = default
@@ -85,7 +118,7 @@ class Screen:
             elif keys is None or key in keys:
                 break
 
-        self.s.addstr(yx[0], yx[1], key, curses.A_STANDOUT)
+        self.window.addstr(yx[0], yx[1], key, curses.A_STANDOUT)
         return key
 
     def draw_choices(
@@ -107,53 +140,51 @@ class Screen:
             choice_colors: dict of choice keys to curses color pair ixs. Optional.
         """
         if start_y is None:
-            start_y = self.s.getyx()[0] + 1
+            start_y = self.window.getyx()[0] + 1
 
         for i, (key, label) in enumerate(choices.items()):
             row = start_y + i
             if choice_colors and key in choice_colors:
-                self.s.addstr(row, 0, f"({key}) ")
-                self.s.addstr(f"{label}", curses.color_pair(choice_colors[key]))
+                self.window.addstr(row, 0, f"({key}) ")
+                self.window.addstr(f"{label}", curses.color_pair(choice_colors[key]))
             else:
-                self.s.addstr(row, 0, f"({key}) {label}")
+                self.window.addstr(row, 0, f"({key}) {label}")
             if key == highlight_key:
                 if choice_colors and key in choice_colors:
-                    self.s.chgat(
+                    self.window.chgat(
                         row,
                         0,
                         3,
                         curses.color_pair(choice_colors[key]) | curses.A_STANDOUT,
                     )
                 else:
-                    self.s.chgat(row, 0, 3, curses.A_STANDOUT)
+                    self.window.chgat(row, 0, 3, curses.A_STANDOUT)
             if key == highlight_line:
                 end_x = 4 + len(choices[key])
                 if choice_colors and key in choice_colors:
-                    self.s.chgat(
+                    self.window.chgat(
                         row,
                         0,
                         end_x,
                         curses.color_pair(choice_colors[key]) | curses.A_STANDOUT,
                     )
                 else:
-                    self.s.chgat(row, 0, end_x, curses.A_STANDOUT)
+                    self.window.chgat(row, 0, end_x, curses.A_STANDOUT)
 
     def draw_prompt(self, msg):
-        self.s.move(self.prompt_y, 0)
-        self.s.deleteln()
-        self.s.insertln()
-        self.s.addstr(msg)
+        self.window.move(self.prompt_y, 0)
+        self.window.clearln()
+        self.window.addstr(msg)
 
     def draw_error_message(self, msg=None):
-        self.s.move(self.error_y, 0)
-        self.s.deleteln()
-        self.s.insertln()
+        self.window.move(self.error_y, 0)
+        self.window.clearln()
         if msg is not None:
             c = (
                 curses.color_pair(1) | curses.A_STANDOUT
             )  # combine color with standout effects with bitwise "or"
-            self.s.addstr(f"!", c)
-            self.s.addstr(f" {msg}", curses.color_pair(1))
+            self.window.addstr(f"!", c)
+            self.window.addstr(f" {msg}", curses.color_pair(1))
 
 
 class WelcomeScreen(Screen):
@@ -166,14 +197,14 @@ class WelcomeScreen(Screen):
     }
 
     def draw(self):
-        self.s.clear()
+        self.window.clear()
         self.draw_title("Let's play Tic Tac Toe!")
         self.draw_description("Which type of game would you like to play?")
         self.draw_choices(self.game_types, highlight_key="1", start_y=3)
-        self.s.refresh()
+        self.window.refresh()
 
         # set prompt 2 lines below choices
-        self.prompt_y = self.s.getyx()[0] + 2
+        self.prompt_y = self.window.getyx()[0] + 2
 
     def get_game_type(self):
         """Returns the game type from a key press."""
@@ -195,7 +226,7 @@ class WelcomeScreen(Screen):
 
         # highlight selected game type
         self.draw_choices(self.game_types, highlight_line=key, start_y=3)
-        self.s.refresh()
+        self.window.refresh()
         time.sleep(self.choice_delay)
 
         return self.game_types[key]
@@ -204,39 +235,39 @@ class WelcomeScreen(Screen):
 class TokenScreen(Screen):
     """The TokenScreen allows players to pick their tokens."""
 
-    def __init__(self, stdscr, player1, player2):
-        super().__init__(stdscr)
+    def __init__(self, window, player1, player2):
+        super().__init__(window)
         self.player1, self.player2 = player1, player2
 
     def draw(self):
-        self.s.clear()
+        self.window.clear()
         self.draw_title("Pick your tokens!")
 
-        self.s.addstr(
+        self.window.addstr(
             2, 0, f"{self.player1}: ", curses.color_pair(self.player1.color_ix)
         )
-        self.player1_token_yx = self.s.getyx()
-        self.s.addstr(
+        self.player1_token_yx = self.window.getyx()
+        self.window.addstr(
             self.player1_token_yx[0],
             self.player1_token_yx[1],
             self.player1.token,
             curses.color_pair(self.player1.color_ix),
         )
 
-        self.s.addstr(
+        self.window.addstr(
             3, 0, f"{self.player2}: ", curses.color_pair(self.player2.color_ix)
         )
-        self.player2_token_yx = self.s.getyx()
-        self.s.addstr(
+        self.player2_token_yx = self.window.getyx()
+        self.window.addstr(
             self.player2_token_yx[0],
             self.player2_token_yx[1],
             self.player2.token,
             curses.color_pair(self.player2.color_ix),
         )
 
-        self.s.refresh()
+        self.window.refresh()
 
-        self.prompt_y = self.s.getyx()[0] + 2
+        self.prompt_y = self.window.getyx()[0] + 2
         self.error_y = self.prompt_y + 1
 
     def update_player_tokens(self):
@@ -274,7 +305,7 @@ class TokenScreen(Screen):
                 self.draw_error_message("You can't use that as a token.")
             else:
                 # "echo" the capitalized token to the screen
-                self.s.addstr(
+                self.window.addstr(
                     token_yx[0],
                     token_yx[1],
                     player.token,
@@ -290,8 +321,8 @@ class DifficultyScreen(Screen):
 
     difficulties = {"1": "Easy", "2": "Medium", "3": "Hard"}
 
-    def __init__(self, stdscr, player1, player2):
-        super().__init__(stdscr)
+    def __init__(self, window, player1, player2):
+        super().__init__(window)
         self.player1, self.player2 = player1, player2
         # Set flag to skip if neither player is a Computer
         self.skip = not (
@@ -300,12 +331,12 @@ class DifficultyScreen(Screen):
         )
 
     def draw(self):
-        self.s.clear()
+        self.window.clear()
         self.draw_choices(self.difficulties, highlight_key="1", start_y=2)
-        self.s.refresh()
+        self.window.refresh()
 
         # set prompt 2 lines below choices
-        self.prompt_y = self.s.getyx()[0] + 2
+        self.prompt_y = self.window.getyx()[0] + 2
 
     def update_computer_difficulties(self):
         if isinstance(self.player1, players.Computer):
@@ -317,15 +348,15 @@ class DifficultyScreen(Screen):
 
     def get_difficulty(self, player):
         self.draw_title(f"Set a difficulty for ")
-        y, x = self.s.getyx()
-        self.s.addstr(y, x, str(player), curses.color_pair(player.color_ix))
+        y, x = self.window.getyx()
+        self.window.addstr(y, x, str(player), curses.color_pair(player.color_ix))
 
         keys = ["1", "2", "3"]
         prompt = f"Enter [1-3]: "
         key = self.get_key(prompt=prompt, keys=keys, default=keys[0], highlight=True)
 
         self.draw_choices(self.difficulties, highlight_line=key, start_y=2)
-        self.s.refresh()
+        self.window.refresh()
         time.sleep(self.choice_delay)
 
         player.difficulty = self.difficulties[key]
@@ -338,8 +369,8 @@ class OrderScreen(Screen):
     choices = {"1": "{player1}", "2": "{player2}", "3": "Flip a coin"}
     player1, player2 = None, None
 
-    def __init__(self, stdscr, player1, player2):
-        super().__init__(stdscr)
+    def __init__(self, window, player1, player2):
+        super().__init__(window)
         self.player1 = player1
         self.player2 = player2
 
@@ -350,13 +381,13 @@ class OrderScreen(Screen):
         self.choice_colors = {"1": self.player1.color_ix, "2": self.player2.color_ix}
 
     def draw(self):
-        self.s.clear()
+        self.window.clear()
         self.draw_title("Who goes first?")
         self.draw_choices(
             self.choices, highlight_key="1", start_y=2, choice_colors=self.choice_colors
         )
-        self.s.refresh()
-        self.prompt_y = self.s.getyx()[0] + 2
+        self.window.refresh()
+        self.prompt_y = self.window.getyx()[0] + 2
 
     def reorder_players(self):
         prompt = "Enter [1-3] or Q to quit: "
@@ -381,7 +412,7 @@ class OrderScreen(Screen):
             start_y=2,
             choice_colors=self.choice_colors,
         )
-        self.s.refresh()
+        self.window.refresh()
         time.sleep(self.choice_delay)
 
         return self.player1, self.player2
@@ -390,11 +421,11 @@ class OrderScreen(Screen):
 class PlayScreen(Screen):
     """The PlayScreen is for playing TicTacToe."""
 
-    def __init__(self, stdscr, board, player1, player2):
-        super().__init__(stdscr)
+    def __init__(self, window, board, player1, player2):
+        super().__init__(window)
         self.player1, self.player2 = player1, player2
         self.board = board
-        self.board_window = BoardWindow.from_stdscr(stdscr, self.board)
+        self.board_window = BoardWindow.from_window(window, self.board)
 
         # Set prompt below board
         self.prompt_y = 8
@@ -416,16 +447,15 @@ class PlayScreen(Screen):
                     break
 
         self.board_window.draw()
-        self.s.move(self.prompt_y, 0)
-        self.s.deleteln()
-        self.s.insertln()
+        self.window.move(self.prompt_y, 0)
+        self.window.clearln()
         if winning_player is None:
-            self.s.addstr("The game ended in a tie.")
+            self.window.addstr("The game ended in a tie.")
             logger.info("Game ended in a tie")
         else:
             self.board_window.highlight_winning_pattern()
             self.board_window.w.refresh()
-            self.s.addstr(
+            self.window.addstr(
                 f"{winning_player} wins!",
                 curses.color_pair(winning_player.color_ix) | curses.A_STANDOUT,
             )
@@ -436,8 +466,8 @@ class PlayScreen(Screen):
         self.get_key(prompt=prompt)
 
     def move_player(self, player):
-        self.s.clear()
-        self.s.addstr(0, 0, f"{player}'s turn", curses.color_pair(player.color_ix))
+        self.window.clear()
+        self.window.addstr(0, 0, f"{player}'s turn", curses.color_pair(player.color_ix))
         self.board_window.draw()
         if isinstance(player, players.Human):
             move = self.get_human_move(player)
@@ -475,11 +505,11 @@ class PlayScreen(Screen):
     def show_computer_move(self, computer_player):
         """Animate the Computer's move."""
         self.draw_prompt(f"{computer_player}'s turn...")
-        self.s.refresh()
+        self.window.refresh()
         move = computer_player.move(self.board)
         self.board[move] = computer_player.token
         logger.info(f"{computer_player} placed a token on {move}")
-        self.s.refresh()
+        self.window.refresh()
         time.sleep(self.choice_delay * 2)
         self.board_window.draw()
         return int(move)
@@ -494,12 +524,12 @@ class EndScreen(Screen):
         self.prompt_y = 8
 
     def draw(self):
-        self.s.clear()
+        self.window.clear()
         self.draw_title("Game over!")
-        self.s.refresh()
+        self.window.refresh()
 
     def ask_play_again(self):
-        self.s.clear()
+        self.window.clear()
         self.draw_title("Game over!")
         self.board_window.draw()
         self.board_window.highlight_winning_pattern()
@@ -520,8 +550,8 @@ class BoardWindow:
         self.space_colors = {}
 
     @classmethod
-    def from_stdscr(cls, stdscr, board, nlines=6, ncols=12, start_y=2, start_x=3):
-        window = stdscr.subwin(nlines, ncols, start_y, start_x)
+    def from_window(cls, window, board, nlines=6, ncols=12, start_y=2, start_x=3):
+        window = window.subwin(nlines, ncols, start_y, start_x)
         return BoardWindow(window, board)
 
     def draw(self):


### PR DESCRIPTION
Creates a new CursesWindow class that isolates all calls to the curses window API. The CursesWindow class is extremely shallow, in that all the methods are simple wrappers around the curses window API, without changing the method names or the arguments. From this point it, it would be easy to refactor for readability even further.

I was pleasantly surprised that this refactor did not break any of the tests. I added in some coverage metrics to make sure that I was testing the affected code, and I was. I definitely think that this dependency injection approach would help me write better tests in the future, though.